### PR TITLE
added csv-stats configurations

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	myCert          = flag.String("cert", "./certs/self_signed/server-cert.pem", "Path of server cert")
 	myKey           = flag.String("pem", "./certs/self_signed/server-key.pem", "Path of server key")
 	kafkaBroker     = flag.String("kafka-broker", "kafka:9092", "Comma seperated list of Kafka brokers each in the form ip:port")
+	csvStats        = flag.Bool("csv-stats", false, "Output telemetry data in CSV format")
 
 	jtimonVersion = "version-not-available"
 	buildTime     = "build-time-not-available"


### PR DESCRIPTION
Related Issue(s): #33 

Added csv-stats to output pre-gnmi and gnmi telemetry data in csv format

Example:
./jtimon-linux-amd64 --config pre-test.json --no-per-packet-goroutines --csv-stats